### PR TITLE
Display images in square aspect ratio

### DIFF
--- a/_sass/_includes/_listing.scss
+++ b/_sass/_includes/_listing.scss
@@ -34,7 +34,7 @@
 	margin: auto;
 	max-width: 1080px;
 	height: 0;
-	padding-bottom: 56.25%;
+	padding-bottom: 100%;
 	background-size: cover;
 	background-position: center;
 	background-repeat: no-repeat;


### PR DESCRIPTION
When used as a value for `padding-bottom` 100% means 100% of the element’s height, meaning the ratio between the width and height of the element will be 1:1. This will probably be better for Instagram images since they’re mostly square.